### PR TITLE
remote machine load checking 

### DIFF
--- a/src/zfs-auto-snapshot.sh
+++ b/src/zfs-auto-snapshot.sh
@@ -1122,17 +1122,18 @@ then
 	if [ -n $opt_limit ]; then
 		runs='1'
 		condition='1'
-		while ( $condition -eq '1' ); do
+		while [ $condition -eq '1' ]; do
 			load=$(eval "$opt_sendtocmd" "uptime")
-			load=$(echo ${load%%\.*} | awk '{print $10}')
+			load=$(echo ${load##*"load average"}} | awk '{print $2}' | awk -F'.' '{print $1}')
 			if [ $load -ge $opt_limit -a $runs -lt '3' ]; then
 				print_log error "Over load limit on remote machine. Going for sleep for 5 minutes. (run #$runs, load still $load)"
 				sleep 300
 			else
 				test $load -ge $opt_limit && opt_send="no"
+				opt_keep=''
 				condition='0'
 			fi
-			runs=$(( $runs + '1' ))
+			runs=$(( $runs + 1 ))
 		done
 	fi
 fi

--- a/src/zfs-auto-snapshot.sh
+++ b/src/zfs-auto-snapshot.sh
@@ -53,6 +53,7 @@ opt_rotation='rr'
 opt_base='day'
 opt_namechange='0'
 opt_factor='1'
+opt_limit='3'
 
 # if pipe needs to be used, uncomment opt_pipe="|". arcfour or blowfish will reduce cpu load caused by ssh and mbuffer will 
 # boost network bandwidth and mitigate low and high peaks during transfer
@@ -1117,6 +1118,22 @@ then
 			exit 301
 			;;
 	esac
+	
+	if [ -n $opt_limit ]; then
+		runs='1'
+		condition='1'
+		while ( $condition -eq '1' ); do
+			load=$(eval "$opt_sendtocmd" "uptime")
+			load=$(echo ${load%%\.*} | awk '{print $10}')
+			if [ $load -ge $opt_limit -a $runs -lt '3' ]; then
+				print_log error "Over load limit on remote machine. Going for sleep for 5 minutes. (run #$runs, load still $load)"
+				sleep 300
+			else
+				condition='0'
+			fi
+			runs=$(( $runs + '1' ))
+		done
+	fi
 
 	MOUNTED_LIST_REM=$(eval do_getmountedfs "remote")
 

--- a/src/zfs-auto-snapshot.sh
+++ b/src/zfs-auto-snapshot.sh
@@ -1129,12 +1129,15 @@ then
 				print_log error "Over load limit on remote machine. Going for sleep for 5 minutes. (run #$runs, load still $load)"
 				sleep 300
 			else
+				test $load -ge $opt_limit && opt_send="no"
 				condition='0'
 			fi
 			runs=$(( $runs + '1' ))
 		done
 	fi
+fi
 
+if [ "$opt_send" != "no" ]; then
 	MOUNTED_LIST_REM=$(eval do_getmountedfs "remote")
 
 	ZFS_REMOTE_LIST=$(eval "$opt_sendtocmd" zfs list -H -t filesystem,volume -s name -o name) \


### PR DESCRIPTION
Added load checking on remote machine. If you have few machines which are
using the same server for backups, could be handy.

During early connect to backup destination, check for load is performed.
If it's over the limit, process sleeps for 5 minutes. This will happen 3
times, then script will continue with local run only. So we are not going
to miss backup schedule.

Based on the -i/-I parameter, this snapshots will be transferred to remote
system on next run.
