### PR TITLE
Added support for SunOS and FreeBSD on remote host

### DIFF
--- a/src/zfs-auto-snapshot.sh
+++ b/src/zfs-auto-snapshot.sh
@@ -1126,10 +1126,10 @@ then
 	PLATFORM_REM=$(eval "$opt_sendtocmd" "uname")
 
 	case "$PLATFORM_REM" in 
-		(Linux|Darwin)
+		(Linux|Darwin|SunOS|FreeBSD)
 			;;
 		(*)
-			print_log error "Remote system not known ($PLATFORM_REM) - needs one of Darwin, Linux. Exiting."
+			print_log error "Remote system not known ($PLATFORM_REM) - needs one of Darwin, Linux, SunOS, FreeBSD. Exiting."
 			exit 301
 			;;
 	esac


### PR DESCRIPTION
Conflicts:
    src/zfs-auto-snapshot.sh

Send zfs snapshots to SunOS (Solaris/SmartOS/OmniOS/etc) and FreeBSD/FreeNAS
